### PR TITLE
WebDAV: Fix PUT to overwrite file if already exists

### DIFF
--- a/src/webdav/webdav-server.ts
+++ b/src/webdav/webdav-server.ts
@@ -108,6 +108,7 @@ export class WebDavServer {
           driveDatabaseManager: this.driveDatabaseManager,
           uploadService: this.uploadService,
           downloadService: this.downloadService,
+          trashService: this.trashService,
           cryptoService: this.cryptoService,
           authService: this.authService,
           networkFacade: networkFacade,


### PR DESCRIPTION
The WebDAV specification [^1] states that in case of a `PUT /…/file`, if the resource `/…/file` already exists and is not a collection (= a directory), then it should be replaced in place (= overwritten).

This commit fixes that.
It can be tested with a simple WebDAV client like `curl`:

    # Write once:
    curl -k -T my-file.txt https://webdav.local.internxt.com:3005
    # Read:
    curl -k https://webdav.local.internxt.com:3005/my-file.txt
    # Overwrite (this should not fail):
    curl -k -T my-file.txt https://webdav.local.internxt.com:3005

Note: I wrote this commit because otherwise the server from `internxt webdav enable` bugs with some WebDAV clients.

[^1]: http://www.webdav.org/specs/rfc4918.html#put-resources