### PR TITLE
WebDAV: Fix wrong percentage inside log for PUT

### DIFF
--- a/src/webdav/handlers/PUT.handler.ts
+++ b/src/webdav/handlers/PUT.handler.ts
@@ -48,7 +48,7 @@ export class PUTRequestHandler implements WebDavMethodHandler {
       req,
       {
         progressCallback: (progress) => {
-          webdavLogger.info(`Upload progress for file ${resource.name}: ${progress}%`);
+          webdavLogger.info(`Upload progress for file ${resource.name}: ${(100*progress).toFixed(2)}%`);
         },
       },
     );


### PR DESCRIPTION
The WebDAV service for PUT operations had an erroneous log: it showed a percentage between 0.00% and 1.00% (instead of 100%).

For example at 95.47% it printed:

    info: Upload progress for file file.zip: 0.9547245810048218% {"service":"internxt-webdav"}

This commit fixes that, logs now look like:

    info: Upload progress for file file.zip: 95.47% {"service":"internxt-webdav"}