### PR TITLE
WebDAV: Fix server closing connection in the middle of long uploads

### DIFF
--- a/src/webdav/webdav-server.ts
+++ b/src/webdav/webdav-server.ts
@@ -144,8 +144,10 @@ export class WebDavServer {
     await this.registerMiddlewares();
     await this.registerHandlers();
 
-    https.createServer(NetworkUtils.getWebdavSSLCerts(), this.app).listen(port, () => {
+    const server = https.createServer(NetworkUtils.getWebdavSSLCerts(), this.app).listen(port, () => {
       webdavLogger.info(`Internxt WebDav server listening at https://${ConfigService.WEBDAV_LOCAL_URL}:${port}`);
     });
+    // Allow long uploads/downloads from WebDAV clients (up to 15 minutes before closing connection):
+    server.requestTimeout = 15 * 60 * 1000;
   }
 }


### PR DESCRIPTION
This fixes the following bug: when uploading a file to the WebDAV server, if the transfer lasted more than 5 minutes, the request would be interrupted and fail: "connection reset" on the WebDAV client side, and in the WebDAV server logs:

    FetchError: request to https://s3.gra.io.cloud.ovh.net/… failed, reason: socket hang up

This is because the default request timeout for Node.JS servers is 5 minutes [^1].

Let's increase it to 15 minutes.

[^1]: https://nodejs.org/api/https.html#serverrequesttimeout