### PR TITLE
WebDAV: Fix PUT to overwrite file if already exists (v2)

### DIFF
--- a/src/services/drive/drive-file.service.ts
+++ b/src/services/drive/drive-file.service.ts
@@ -51,6 +51,39 @@ export class DriveFileService {
     };
   };
 
+  public replaceFile = async (previousFileUuid: string, payload: {
+    name: string;
+    type: string;
+    size: number;
+    folderId: number;
+    fileId: string;
+    bucket: string;
+  }): Promise<DriveFileItem> => {
+    const storageClient = SdkManager.instance.getStorage();
+    const encryptedName = aes.encrypt(
+      payload.name,
+      `${ConfigService.instance.get('APP_CRYPTO_SECRET2')}-${payload.folderId}`,
+      CryptoUtils.getAesInit(),
+    );
+    const driveFile = await storageClient.replaceFile(
+      previousFileUuid, {fileId: payload.fileId, size: payload.size});
+
+    return {
+      size: Number(driveFile.size),
+      uuid: driveFile.uuid,
+      encryptedName,
+      name: payload.name,
+      bucket: payload.bucket,
+      createdAt: new Date(driveFile.createdAt),
+      updatedAt: new Date(driveFile.updatedAt),
+      fileId: payload.fileId,
+      id: driveFile.id,
+      type: payload.type,
+      status: driveFile.status,
+      folderId: driveFile.folderId,
+    };
+  };
+
   public getFileMetadata = async (uuid: string): Promise<DriveFileItem> => {
     const storageClient = SdkManager.instance.getStorage(true);
 


### PR DESCRIPTION
This is another implementation of my fix proposed at https://github.com/internxt/cli/pull/92, with suggestions from @PixoDev. Instead of trashing + uploading, it replaces the file in place.

The WebDAV specification [^1] states that in case of a `PUT /…/file`, if the resource `/…/file` already exists and is not a collection (= a directory), then it should be replaced in place (= overwritten).

This commit can be tested with a simple WebDAV client like `curl`:

    # Write once:
    curl -k -T my-file.txt https://webdav.local.internxt.com:3005
    # Read:
    curl -k https://webdav.local.internxt.com:3005/my-file.txt
    # Overwrite (this should not fail):
    curl -k -T my-file.txt https://webdav.local.internxt.com:3005

Note: I wrote this commit because otherwise the server from `internxt webdav enable` bugs with some WebDAV clients.

[^1]: http://www.webdav.org/specs/rfc4918.html#put-resources