### PR TITLE
[_]: fix/bump-to-internxt-sdk-1.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@internxt/inxt-js": "^2.0.11",
     "@internxt/lib": "^1.2.1",
-    "@internxt/sdk": "^1.5.25",
+    "@internxt/sdk": "1.6.4",
     "@oclif/core": "^3",
     "axios": "^1.7.7",
     "bip39": "^3.1.0",

--- a/src/commands/create-folder.ts
+++ b/src/commands/create-folder.ts
@@ -57,7 +57,7 @@ export default class CreateFolder extends Command {
     const newFolder = await createNewFolder;
     CLIUtils.done();
     CLIUtils.success(
-      `Folder ${newFolder.plain_name} created successfully, view it at view it at ${ConfigService.instance.get('DRIVE_URL')}/folder/${newFolder.uuid}`,
+      `Folder ${newFolder.plainName} created successfully, view it at view it at ${ConfigService.instance.get('DRIVE_URL')}/folder/${newFolder.uuid}`,
     );
   }
 }

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -10,10 +10,10 @@ export class CryptoService {
   public static readonly instance: CryptoService = new CryptoService();
 
   public static readonly cryptoProvider: CryptoProvider = {
-    encryptPasswordHash(password: Password, encryptedSalt: string): string {
+    encryptPasswordHash(password: Password, encryptedSalt: string): Promise<string> {
       const salt = CryptoService.instance.decryptText(encryptedSalt);
       const hashObj = CryptoService.instance.passToHash({ password, salt });
-      return CryptoService.instance.encryptText(hashObj.hash);
+      return Promise.resolve(CryptoService.instance.encryptText(hashObj.hash));
     },
     async generateKeys(password: Password): Promise<Keys> {
       const { privateKeyArmoredEncrypted, publicKeyArmored, revocationCertificate } =
@@ -22,6 +22,14 @@ export class CryptoService {
         privateKeyEncrypted: privateKeyArmoredEncrypted,
         publicKey: publicKeyArmored,
         revocationCertificate: revocationCertificate,
+        ecc: {
+          privateKeyEncrypted: privateKeyArmoredEncrypted,
+          publicKey: publicKeyArmored,
+        },
+        kyber: {
+          privateKeyEncrypted: null,
+          publicKey: null
+        }
       };
       return keys;
     },

--- a/src/webdav/handlers/MKCOL.handler.ts
+++ b/src/webdav/handlers/MKCOL.handler.ts
@@ -45,7 +45,7 @@ export class MKCOLRequestHandler implements WebDavMethodHandler {
 
     await driveDatabaseManager.createFolder(
       {
-        name: newFolder.plain_name,
+        name: newFolder.plainName,
         status: 'EXISTS',
         encryptedName: newFolder.name,
         bucket: newFolder.bucket,

--- a/test/fixtures/auth.fixture.ts
+++ b/test/fixtures/auth.fixture.ts
@@ -1,7 +1,7 @@
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import crypto from 'crypto';
 
-export const UserFixture = {
+export const UserFixture: UserSettings = {
   userId: crypto.randomBytes(16).toString('hex'),
   uuid: crypto.randomBytes(16).toString('hex'),
   email: crypto.randomBytes(16).toString('hex'),
@@ -20,6 +20,17 @@ export const UserFixture = {
   privateKey: crypto.randomBytes(16).toString('hex'),
   publicKey: crypto.randomBytes(16).toString('hex'),
   revocationKey: crypto.randomBytes(16).toString('hex'),
+  keys: {
+    ecc: {
+      privateKey: crypto.randomBytes(16).toString('hex'),
+      publicKey: crypto.randomBytes(16).toString('hex'),
+      revocationKey: crypto.randomBytes(16).toString('hex'),
+    },
+    kyber: {
+      privateKyberKey: crypto.randomBytes(16).toString('hex'),
+      publicKyberKey: crypto.randomBytes(16).toString('hex'),
+    }
+  },
   teams: false,
   appSumoDetails: null,
   registerCompleted: true,
@@ -47,6 +58,17 @@ export const UserSettingsFixture: UserSettings = {
   privateKey: UserFixture.privateKey,
   publicKey: UserFixture.publicKey,
   revocationKey: UserFixture.revocationKey,
+  keys: {
+    ecc: {
+      privateKey: UserFixture.keys.ecc.privateKey,
+      publicKey: UserFixture.keys.ecc.publicKey,
+      revocationKey: UserFixture.revocationKey,
+    },
+    kyber: {
+      privateKyberKey: UserFixture.keys.kyber.privateKyberKey,
+      publicKyberKey: UserFixture.keys.kyber.publicKyberKey,
+    }
+  },
   teams: UserFixture.teams,
   appSumoDetails: UserFixture.appSumoDetails,
   registerCompleted: UserFixture.registerCompleted,

--- a/test/services/crypto.service.test.ts
+++ b/test/services/crypto.service.test.ts
@@ -57,7 +57,7 @@ describe('Crypto service', () => {
     expect(spyConfigService).to.be.calledWith(envEndpoint.key);
   });
 
-  it('When a password is hashed using CryptoProvider, then it is hashed correctly', () => {
+  it('When a password is hashed using CryptoProvider, then it is hashed correctly', async () => {
     const envEndpoint: { key: keyof ConfigKeys; value: string } = {
       key: 'APP_CRYPTO_SECRET',
       value: crypto.randomBytes(16).toString('hex'),
@@ -74,7 +74,7 @@ describe('Crypto service', () => {
 
     const encryptedSalt = CryptoService.instance.encryptText(password.salt);
     const hashedAndEncryptedPassword = CryptoService.cryptoProvider.encryptPasswordHash(password.value, encryptedSalt);
-    const hashedPassword = CryptoService.instance.decryptText(hashedAndEncryptedPassword);
+    const hashedPassword = CryptoService.instance.decryptText(await hashedAndEncryptedPassword);
 
     const expectedHashedPassword = crypto
       .pbkdf2Sync(password.value, Buffer.from(password.salt, 'hex'), 10000, 256 / 8, 'sha1')
@@ -110,6 +110,14 @@ describe('Crypto service', () => {
       privateKeyEncrypted: keysReturned.privateKeyArmoredEncrypted,
       publicKey: keysReturned.publicKeyArmored,
       revocationCertificate: keysReturned.revocationCertificate,
+      kyber: {
+        privateKeyEncrypted: null,
+        publicKey: null,
+      },
+      ecc: {
+        privateKeyEncrypted: keysReturned.privateKeyArmoredEncrypted,
+        publicKey: keysReturned.publicKeyArmored,
+      }
     };
 
     const resultedKeys = await CryptoService.cryptoProvider.generateKeys(password);

--- a/test/services/drive/drive-folder.service.test.ts
+++ b/test/services/drive/drive-folder.service.test.ts
@@ -84,12 +84,19 @@ describe('Drive folder Service', () => {
       bucket: 'bucket1',
       id: 0,
       name: 'folder-1',
-      plain_name: 'folder-1',
-      createdAt: '',
-      updatedAt: '',
+      plainName: 'folder-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
       userId: 0,
       uuid: '1234-5678-9012-3456',
       parentUuid: '0123-5678-9012-3456',
+      encryptVersion: 'aes-03',
+      creationTime: new Date(),
+      deleted: false,
+      deletedAt: null,
+      modificationTime: new Date(),
+      removed: false,
+      removedAt: null,
     };
     sandbox
       .stub(Storage.prototype, 'createFolder')
@@ -101,6 +108,6 @@ describe('Drive folder Service', () => {
     });
 
     const newFolder = await createFolder;
-    expect(newFolder.plain_name).to.be.eq('folder-1');
+    expect(newFolder.plainName).to.be.eq('folder-1');
   });
 });

--- a/test/webdav/handlers/MKCOL.handler.test.ts
+++ b/test/webdav/handlers/MKCOL.handler.test.ts
@@ -50,12 +50,19 @@ describe('MKCOL request handler', () => {
       bucket: 'bucket1',
       id: 0,
       name: 'folder-1',
-      plain_name: 'FolderA',
-      createdAt: '',
-      updatedAt: '',
+      plainName: 'FolderA',
+      createdAt: new Date(),
+      updatedAt: new Date(),
       userId: 0,
       uuid: '1234-5678-9012-3456',
       parentUuid: '0123-5678-9012-3456',
+      removed: false,
+      removedAt: null,
+      creationTime: new Date(),
+      deleted: false,
+      deletedAt: null,
+      encryptVersion: 'aes-03',
+      modificationTime: new Date(),
     };
 
     const getRequestedResourceStub = sandbox

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,19 +1334,19 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/5bd220b8de76734448db5475b3e0c01f9d22c19b#5bd220b8de76734448db5475b3e0c01f9d22c19b"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
+"@internxt/sdk@1.6.4":
+  version "1.6.4"
+  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.6.4/79720d5d4ff3a0f12da4dbd4094d666f6f8a1854#79720d5d4ff3a0f12da4dbd4094d666f6f8a1854"
+  integrity sha512-XMub1zcRwf6C/3fWlHDVrqUTRD7U4M279dUB4Z4f5dPPL7JdYdDlCe3nzZN56yLgHEty7CJJ9kWVJT9357/Q5A==
+  dependencies:
+    axios "^0.28.0"
+    query-string "^7.1.0"
+    uuid "^11.0.2"
+
 "@internxt/sdk@^1.4.27":
   version "1.4.70"
   resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.4.70/6e07263dbaa130269323d21b895ea8c0e7d1cc3c#6e07263dbaa130269323d21b895ea8c0e7d1cc3c"
   integrity sha512-bqtTsYjT9kjkxFfqFVOrxlp3vlCtQdLhH9LWOF4DSIc5j/EnDh7hTKwSGo+mzMdqYYeivQB3cqrxr6QiyBMkcw==
-  dependencies:
-    axios "^0.24.0"
-    query-string "^7.1.0"
-    uuid "^8.3.2"
-
-"@internxt/sdk@^1.5.25":
-  version "1.5.25"
-  resolved "https://npm.pkg.github.com/download/@internxt/sdk/1.5.25/c0dc19d92b4002d897c5cc177168f36c9c34001f#c0dc19d92b4002d897c5cc177168f36c9c34001f"
-  integrity sha512-FTMGTv2p3ZKl91BMhBlig7CyZ45hTWoSUDf2cyM/iIZtdublGbMipG644tIlZbtrEDmQRA8XCO2NjkPV3IjXow==
   dependencies:
     axios "^0.24.0"
     query-string "^7.1.0"
@@ -3614,6 +3614,15 @@ axios@^0.24.0:
   dependencies:
     follow-redirects "^1.14.4"
 
+axios@^0.28.0:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.1.tgz#2a7bcd34a3837b71ee1a5ca3762214b86b703e70"
+  integrity sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axios@^1.7.7:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
@@ -5621,7 +5630,7 @@ follow-redirects@^1.14.0, follow-redirects@^1.14.4:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
-follow-redirects@^1.15.6:
+follow-redirects@^1.15.0, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -10134,6 +10143,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^11.0.2:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
+  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
Upgrades to Internxt SDK 1.6.4 as the current version has incompatibilities due to a mixed data structure on the login step, to adapt the project, the following changes have been made: 
- Adjusting `plain_name` field to `plainName`
- Adding missing crypto keys making the login fail
- Making `encryptPasswordHash` asynchronous
- Consdering the new fields of the folder entity: `deleted`, `removed`, `modificationTime`, `creationTime`, `encryptVersion` in the tests