### PR TITLE
Fix internxt list --non-interactive

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -34,7 +34,7 @@ export default class List extends Command {
 
     let folderUuid = await this.getFolderUuid(flags['id'], nonInteractive);
 
-    if (folderUuid.trim().length === 0) {
+    if (!folderUuid || folderUuid.trim().length === 0) {
       // folderId is empty from flags&prompt, which means we should use RootFolderUuid
       folderUuid = userCredentials.root_folder_uuid;
     }
@@ -114,7 +114,7 @@ export default class List extends Command {
     this.exit(1);
   }
 
-  public getFolderUuid = async (folderUuidFlag: string | undefined, nonInteractive: boolean): Promise<string> => {
+  public getFolderUuid = async (folderUuidFlag: string | undefined, nonInteractive: boolean): Promise<string | undefined> => {
     let folderUuid = CLIUtils.getValueFromFlag(
       {
         value: folderUuidFlag,
@@ -125,7 +125,7 @@ export default class List extends Command {
       nonInteractive,
       (folderUuid: string) => ValidationService.instance.validateUUIDv4(folderUuid),
     );
-    if (!folderUuid) {
+    if (!folderUuid && !nonInteractive) {
       folderUuid = (await this.getFolderUuidInteractively()).trim();
     }
     return folderUuid;


### PR DESCRIPTION
Since version 1.3.1 and commit 64f9aec, the command `internxt list --non-interactive` doesn't work anymore, because it asks for an interactive input from the user:

    $ internxt list --non-interactive
    What is the folder id you want to list? (leave empty for the root folder):

This commit fixes by assuming "root folder" when no UUID is passed (samed behavior as before 1.3.1).