### PR TITLE
WebDAV server improvement for better compliance with WebDAV specifications

### DIFF
--- a/src/utils/webdav.utils.ts
+++ b/src/utils/webdav.utils.ts
@@ -101,16 +101,16 @@ export class WebDavUtils {
       // if resource has a parentPath it means it's a subfolder then try to get it; if it throws an error it means it doesn't 
       // exist and we should throw a 409 error in compliance with the WebDAV RFC
       // catch the error during getting parent folder and throw a 409 error in compliance with the WebDAV RFC
-
       try {
         item = await driveFolderService?.getFolderMetadataByPath(resource.url);
       }
-      // TODO: get the exact error type from the SDK, it should be a 404 error
       catch (error: any) {
         // if the error is a 404 error, it means the resource doesn't exist
         // in this case, throw a 409 error in compliance with the WebDAV RFC
-        
-        throw new ConflictError(`Resource not found on Internxt Drive at ${resource.url}`);
+        if (error.status === 404) {
+          throw new ConflictError(`Resource not found on Internxt Drive at ${resource.url}`);
+        }
+        throw error;
       }
     }
     if (resource.type === 'file') {

--- a/src/utils/webdav.utils.ts
+++ b/src/utils/webdav.utils.ts
@@ -98,7 +98,6 @@ export class WebDavUtils {
     let item: DriveFileItem | DriveFolderItem | undefined = undefined;
 
     if (resource.type === 'folder') {
-      webdavLogger.info('Andrea: resource ->', { resource });
       // if resource has a parentPath it means it's a subfolder then try to get it; if it throws an error it means it doesn't 
       // exist and we should throw a 409 error in compliance with the WebDAV RFC
       // catch the error during getting parent folder and throw a 409 error in compliance with the WebDAV RFC
@@ -110,7 +109,7 @@ export class WebDavUtils {
       catch (error: any) {
         // if the error is a 404 error, it means the resource doesn't exist
         // in this case, throw a 409 error in compliance with the WebDAV RFC
-        // if error is of type AppError, throw it
+        
         throw new ConflictError(`Resource not found on Internxt Drive at ${resource.url}`);
       }
     }

--- a/src/webdav/handlers/MKCOL.handler.ts
+++ b/src/webdav/handlers/MKCOL.handler.ts
@@ -7,7 +7,7 @@ import { webdavLogger } from '../../utils/logger.utils';
 import { XMLUtils } from '../../utils/xml.utils';
 import { AsyncUtils } from '../../utils/async.utils';
 import { DriveFolderItem } from '../../types/drive.types';
-import { MethodNotAllowed } from '../../utils/errors.utils';
+import { MethodNotAllowed, UnsupportedMediaTypeError } from '../../utils/errors.utils';
 
 export class MKCOLRequestHandler implements WebDavMethodHandler {
   constructor(
@@ -15,11 +15,16 @@ export class MKCOLRequestHandler implements WebDavMethodHandler {
       driveDatabaseManager: DriveDatabaseManager;
       driveFolderService: DriveFolderService;
     },
-  ) {}
+  ) { }
 
   handle = async (req: Request, res: Response) => {
     const { driveDatabaseManager, driveFolderService } = this.dependencies;
     const resource = await WebDavUtils.getRequestedResource(req);
+
+    // if body is not empty throw a 500 error
+    if (Object.keys(req.body).length > 0) {
+      throw new UnsupportedMediaTypeError('Body not allowed for MKCOL method');
+    }
 
     webdavLogger.info(`[MKCOL] Request received for ${resource.type} at ${resource.url}`);
 
@@ -44,7 +49,7 @@ export class MKCOLRequestHandler implements WebDavMethodHandler {
     }
 
     if (folderAlreadyExists) {
-      webdavLogger.info(`[MKCOL] ❌ Folder already exists`); 
+      webdavLogger.info(`[MKCOL] ❌ Folder already exists`);
       throw new MethodNotAllowed('Folder already exists');
     }
 

--- a/src/webdav/handlers/MKCOL.handler.ts
+++ b/src/webdav/handlers/MKCOL.handler.ts
@@ -7,7 +7,7 @@ import { webdavLogger } from '../../utils/logger.utils';
 import { XMLUtils } from '../../utils/xml.utils';
 import { AsyncUtils } from '../../utils/async.utils';
 import { DriveFolderItem } from '../../types/drive.types';
-import { MethodNotAllowed, UnsupportedMediaTypeError } from '../../utils/errors.utils';
+import { MethodNotAllowed } from '../../utils/errors.utils';
 
 export class MKCOLRequestHandler implements WebDavMethodHandler {
   constructor(
@@ -37,10 +37,12 @@ export class MKCOLRequestHandler implements WebDavMethodHandler {
     try {
       await driveFolderService.getFolderMetadataByPath(resource.url);
     }
-    // TODO: This is a bad practice, we should catch a specific error (e.g. FolderNotFound) instead of a generic one;
     // In this case a 404 error must spefically catched
-    catch (error) {
-      folderAlreadyExists = false;
+    catch (error: any) {
+      // check if the error is a 404 error
+      if (error.status === 404) {
+        folderAlreadyExists = false;
+      }
     }
 
     if (folderAlreadyExists) {

--- a/src/webdav/handlers/MKCOL.handler.ts
+++ b/src/webdav/handlers/MKCOL.handler.ts
@@ -21,11 +21,6 @@ export class MKCOLRequestHandler implements WebDavMethodHandler {
     const { driveDatabaseManager, driveFolderService } = this.dependencies;
     const resource = await WebDavUtils.getRequestedResource(req);
 
-    // if body is not empty throw a 500 error
-    if (Object.keys(req.body).length > 0) {
-      throw new UnsupportedMediaTypeError('Body not allowed for MKCOL method');
-    }
-
     webdavLogger.info(`[MKCOL] Request received for ${resource.type} at ${resource.url}`);
 
     const parentResource = await WebDavUtils.getRequestedResource(resource.parentPath);

--- a/src/webdav/handlers/PUT.handler.ts
+++ b/src/webdav/handlers/PUT.handler.ts
@@ -154,6 +154,6 @@ export class PUTRequestHandler implements WebDavMethodHandler {
 
     await driveDatabaseManager.createFile(file, resource.path.dir + '/');
 
-    res.status(200).send();
+    res.status(201).send();
   };
 }

--- a/src/webdav/middewares/mkcol.middleware.ts
+++ b/src/webdav/middewares/mkcol.middleware.ts
@@ -1,0 +1,24 @@
+import { RequestHandler } from 'express';
+
+export const MkcolMiddleware: RequestHandler = (req, _, next) => {
+  // if request content types are not 'application/xml', 'text/xml' or not defined, return 415
+  if (req.method === 'MKCOL') {
+    if (req.get('Content-Type')) {
+      if (!req.is('application/xml') && !req.is('text/xml')) {
+        return next({
+          status: 415,
+          message: 'Unsupported Media Type',
+        });
+      }
+    }
+    // body must be empty
+    if (req.body && Object.keys(req.body).length > 0) {
+      return next({
+        status: 415,
+        message: 'Unsupported Media Type',
+      });
+    }
+  }
+
+  next();
+};

--- a/src/webdav/webdav-server.ts
+++ b/src/webdav/webdav-server.ts
@@ -69,9 +69,9 @@ export class WebDavServer {
   };
 
   private readonly registerMiddlewares = async () => {
+    this.app.use(bodyParser.text({ type: ['application/xml', 'text/xml'] }));
     this.app.use(ErrorHandlingMiddleware);
     this.app.use(MkcolMiddleware);
-    this.app.use(bodyParser.text({ type: ['application/xml', 'text/xml'] }));
     this.app.use(AuthMiddleware(AuthService.instance));
     this.app.use(
       RequestLoggerMiddleware({

--- a/src/webdav/webdav-server.ts
+++ b/src/webdav/webdav-server.ts
@@ -68,8 +68,9 @@ export class WebDavServer {
   };
 
   private readonly registerMiddlewares = async () => {
-    this.app.use(bodyParser.text({ type: ['application/xml', 'text/xml'] }));
     this.app.use(ErrorHandlingMiddleware);
+    // include body of the request without any parsing
+    this.app.use(bodyParser.raw({ type: '*/*' }));
     this.app.use(AuthMiddleware(AuthService.instance));
     this.app.use(
       RequestLoggerMiddleware({

--- a/src/webdav/webdav-server.ts
+++ b/src/webdav/webdav-server.ts
@@ -29,6 +29,7 @@ import { MOVERequestHandler } from './handlers/MOVE.handler';
 import { COPYRequestHandler } from './handlers/COPY.handler';
 import { TrashService } from '../services/drive/trash.service';
 import { Environment } from '@internxt/inxt-js';
+import { MkcolMiddleware } from './middewares/mkcol.middleware';
 
 export class WebDavServer {
   constructor(
@@ -69,8 +70,8 @@ export class WebDavServer {
 
   private readonly registerMiddlewares = async () => {
     this.app.use(ErrorHandlingMiddleware);
-    // include body of the request without any parsing
-    this.app.use(bodyParser.raw({ type: '*/*' }));
+    this.app.use(MkcolMiddleware);
+    this.app.use(bodyParser.text({ type: ['application/xml', 'text/xml'] }));
     this.app.use(AuthMiddleware(AuthService.instance));
     this.app.use(
       RequestLoggerMiddleware({

--- a/test/webdav/handlers/PUT.handler.test.ts
+++ b/test/webdav/handlers/PUT.handler.test.ts
@@ -138,7 +138,7 @@ describe('PUT request handler', () => {
     const createDBFileStub = vi.spyOn(driveDatabaseManager, 'createFile').mockResolvedValue(fileFixture);
 
     await sut.handle(request, response);
-    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.status).toHaveBeenCalledWith(201);
     expect(getRequestedResourceStub).toHaveBeenCalledTimes(2);
     expect(getAndSearchItemFromResourceStub).toHaveBeenCalledTimes(2);
     expect(getAuthDetailsStub).toHaveBeenCalledOnce();
@@ -206,7 +206,7 @@ describe('PUT request handler', () => {
     const createDBFileStub = vi.spyOn(driveDatabaseManager, 'createFile').mockResolvedValue(fileFixture);
 
     await sut.handle(request, response);
-    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.status).toHaveBeenCalledWith(201);
     expect(getRequestedResourceStub).toHaveBeenCalledTimes(2);
     expect(getAndSearchItemFromResourceStub).toHaveBeenCalledTimes(2);
     expect(getAuthDetailsStub).toHaveBeenCalledOnce();


### PR DESCRIPTION
This PR aim to solve the following WebDAV integration issue (tested with `litmus`)
```
 3. put_get............... WARNING: PUT of new resource gave 200, should be 201
    ...................... FAIL (GET of `/litmus/res' failed: 404 Not Found)
    ...................... WARNING: PUT of new resource gave 200, should be 201
    ...................... FAIL (GET of `/litmus/res-%e2%82%ac' failed: 404 Not Found)
    ...................... WARNING: MKCOL with missing intermediate gave 404, should be 409
    ...................... pass (with 1 warning)
11. mkcol_again........... WARNING: MKCOL on existing collection gave 400, should be 405 (RFC2518:8.3.2)
    ...................... pass (with 1 warning)
13. mkcol_no_parent....... WARNING: MKCOL with missing intermediate gave 404, should be 409 (RFC2518:8.3.1)
    ...................... pass (with 1 warning)
14. mkcol_with_body....... FAIL (MKCOL with weird body must fail (RFC2518:8.3.1))
```

This is the situation before the changes

![image](https://github.com/user-attachments/assets/8db8813c-781b-4f49-a383-f142d08cae0b)
And this is after the changes

![image](https://github.com/user-attachments/assets/aab4885e-e4ca-4a3e-99d0-fceef5eb2613)

Notes:
 - I was not able to fix the remaning two issues; I thought it was a timing issue between the PUT and the GET but even adding a timeout of 40 seconds between the two action solve the issue
 - There's one test that fail (in MKCOL.handler.test.ts), that need to be adapted to the new changes
