### PR TITLE
[_]: fix/webdav-not-found-errors

### DIFF
--- a/src/utils/webdav.utils.ts
+++ b/src/utils/webdav.utils.ts
@@ -4,8 +4,6 @@ import { WebDavRequestedResource } from '../types/webdav.types';
 import { DriveFolderService } from '../services/drive/drive-folder.service';
 import { DriveFileService } from '../services/drive/drive-file.service';
 import { DriveFileItem, DriveFolderItem } from '../types/drive.types';
-import { ConflictError, NotFoundError } from './errors.utils';
-import AppError from '@internxt/sdk/dist/shared/types/errors';
 
 export class WebDavUtils {
   static joinURL(...pathComponents: string[]): string {
@@ -59,39 +57,7 @@ export class WebDavUtils {
     }
   }
 
-  static async getDriveItemFromResource(
-    resource: WebDavRequestedResource,
-    driveFolderService?: DriveFolderService,
-    driveFileService?: DriveFileService,
-  ): Promise<DriveFileItem | DriveFolderItem | undefined> {
-    let item: DriveFileItem | DriveFolderItem | undefined = undefined;
-
-    if (resource.type === 'folder') {
-      // if resource has a parentPath it means it's a subfolder then try to get it; if it throws an error it means it doesn't
-      // exist and we should throw a 409 error in compliance with the WebDAV RFC
-      // catch the error during getting parent folder and throw a 409 error in compliance with the WebDAV RFC
-      try {
-        item = await driveFolderService?.getFolderMetadataByPath(resource.url);
-      } catch (error) {
-        // if the error is a 404 error, it means the resource doesn't exist
-        // in this case, throw a 409 error in compliance with the WebDAV RFC
-        if ((error as AppError).status === 404) {
-          throw new ConflictError(`Resource not found on Internxt Drive at ${resource.url}`);
-        }
-        throw error;
-      }
-    }
-    if (resource.type === 'file') {
-      try {
-        item = await driveFileService?.getFileMetadataByPath(resource.url);
-      } catch {
-        //no op
-      }
-    }
-    return item;
-  }
-
-  static async getAndSearchItemFromResource({
+  static async getDriveItemFromResource({
     resource,
     driveFolderService,
     driveFileService,
@@ -99,11 +65,19 @@ export class WebDavUtils {
     resource: WebDavRequestedResource;
     driveFolderService?: DriveFolderService;
     driveFileService?: DriveFileService;
-  }): Promise<DriveFileItem | DriveFolderItem> {
-    const driveItem = await this.getDriveItemFromResource(resource, driveFolderService, driveFileService);
-    if (!driveItem) {
-      throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+  }): Promise<DriveFileItem | DriveFolderItem | undefined> {
+    let item: DriveFileItem | DriveFolderItem | undefined = undefined;
+
+    try {
+      if (resource.type === 'folder') {
+        item = await driveFolderService?.getFolderMetadataByPath(resource.url);
+      }
+      if (resource.type === 'file') {
+        item = await driveFileService?.getFileMetadataByPath(resource.url);
+      }
+    } catch {
+      //no op
     }
-    return driveItem;
+    return item;
   }
 }

--- a/src/webdav/handlers/DELETE.handler.ts
+++ b/src/webdav/handlers/DELETE.handler.ts
@@ -5,6 +5,7 @@ import { TrashService } from '../../services/drive/trash.service';
 import { webdavLogger } from '../../utils/logger.utils';
 import { DriveFileService } from '../../services/drive/drive-file.service';
 import { DriveFolderService } from '../../services/drive/drive-folder.service';
+import { NotFoundError } from '../../utils/errors.utils';
 
 export class DELETERequestHandler implements WebDavMethodHandler {
   constructor(
@@ -20,11 +21,15 @@ export class DELETERequestHandler implements WebDavMethodHandler {
     const resource = await WebDavUtils.getRequestedResource(req);
     webdavLogger.info(`[DELETE] Request received for ${resource.type} at ${resource.url}`);
 
-    const driveItem = await WebDavUtils.getAndSearchItemFromResource({
+    const driveItem = await WebDavUtils.getDriveItemFromResource({
       resource,
       driveFolderService,
       driveFileService: driveFileService,
     });
+
+    if (!driveItem) {
+      throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+    }
 
     webdavLogger.info(`[DELETE] [${driveItem.uuid}] Trashing ${resource.type}`);
     await trashService.trashItems({

--- a/src/webdav/handlers/GET.handler.ts
+++ b/src/webdav/handlers/GET.handler.ts
@@ -30,10 +30,15 @@ export class GETRequestHandler implements WebDavMethodHandler {
     if (resource.type === 'folder') throw new NotFoundError('Folders cannot be listed with GET. Use PROPFIND instead.');
 
     webdavLogger.info(`[GET] Request received for ${resource.type} at ${resource.url}`);
-    const driveFile = (await WebDavUtils.getAndSearchItemFromResource({
+    const driveItem = await WebDavUtils.getDriveItemFromResource({
       resource,
       driveFileService,
-    })) as DriveFileItem;
+    });
+
+    if (!driveItem) {
+      throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+    }
+    const driveFile = driveItem as DriveFileItem;
 
     webdavLogger.info(`[GET] [${driveFile.uuid}] Found Drive File`);
 

--- a/src/webdav/handlers/HEAD.handler.ts
+++ b/src/webdav/handlers/HEAD.handler.ts
@@ -5,6 +5,7 @@ import { webdavLogger } from '../../utils/logger.utils';
 import { DriveFileService } from '../../services/drive/drive-file.service';
 import { DriveFileItem } from '../../types/drive.types';
 import { NetworkUtils } from '../../utils/network.utils';
+import { NotFoundError } from '../../utils/errors.utils';
 
 export class HEADRequestHandler implements WebDavMethodHandler {
   constructor(
@@ -25,10 +26,15 @@ export class HEADRequestHandler implements WebDavMethodHandler {
     webdavLogger.info(`[HEAD] Request received for ${resource.type} at ${resource.url}`);
 
     try {
-      const driveFile = (await WebDavUtils.getAndSearchItemFromResource({
+      const driveItem = await WebDavUtils.getDriveItemFromResource({
         resource,
         driveFileService,
-      })) as DriveFileItem;
+      });
+
+      if (!driveItem) {
+        throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+      }
+      const driveFile = driveItem as DriveFileItem;
 
       webdavLogger.info(`[HEAD] [${driveFile.uuid}] Found Drive File`);
 

--- a/src/webdav/handlers/MKCOL.handler.ts
+++ b/src/webdav/handlers/MKCOL.handler.ts
@@ -6,7 +6,7 @@ import { webdavLogger } from '../../utils/logger.utils';
 import { XMLUtils } from '../../utils/xml.utils';
 import { AsyncUtils } from '../../utils/async.utils';
 import { DriveFolderItem } from '../../types/drive.types';
-import { MethodNotAllowed } from '../../utils/errors.utils';
+import { ConflictError, MethodNotAllowed } from '../../utils/errors.utils';
 
 export class MKCOLRequestHandler implements WebDavMethodHandler {
   constructor(
@@ -23,10 +23,19 @@ export class MKCOLRequestHandler implements WebDavMethodHandler {
 
     const parentResource = await WebDavUtils.getRequestedResource(resource.parentPath, false);
 
-    const parentFolderItem = (await WebDavUtils.getAndSearchItemFromResource({
+    const parentDriveItem = await WebDavUtils.getDriveItemFromResource({
       resource: parentResource,
       driveFolderService,
-    })) as DriveFolderItem;
+    });
+
+    if (!parentDriveItem) {
+      // WebDAV RFC
+      // When the MKCOL operation creates a new collection resource,
+      // all ancestors MUST already exist, or the method MUST fail
+      // with a 409 (Conflict) status code
+      throw new ConflictError(`Parent folders not found on Internxt Drive at ${resource.url}`);
+    }
+    const parentFolderItem = parentDriveItem as DriveFolderItem;
 
     let folderAlreadyExists = true;
     // try to get the folder from the drive before creating it

--- a/src/webdav/handlers/MKCOL.handler.ts
+++ b/src/webdav/handlers/MKCOL.handler.ts
@@ -37,14 +37,12 @@ export class MKCOLRequestHandler implements WebDavMethodHandler {
     }
     const parentFolderItem = parentDriveItem as DriveFolderItem;
 
-    let folderAlreadyExists = true;
-    // try to get the folder from the drive before creating it
-    // The method getFolderMetadataByPath will throw an error if the folder does not exist, so we need to catch it
-    try {
-      await driveFolderService.getFolderMetadataByPath(resource.url);
-    } catch {
-      folderAlreadyExists = false;
-    }
+    const driveFolderItem = await WebDavUtils.getDriveItemFromResource({
+      resource,
+      driveFolderService,
+    });
+
+    const folderAlreadyExists = !!driveFolderItem;
 
     if (folderAlreadyExists) {
       webdavLogger.info(`[MKCOL] ❌ Folder '${resource.url}' already exists`);

--- a/src/webdav/handlers/MOVE.handler.ts
+++ b/src/webdav/handlers/MOVE.handler.ts
@@ -30,11 +30,15 @@ export class MOVERequestHandler implements WebDavMethodHandler {
 
     webdavLogger.info('[MOVE] Destination resource found', { destinationResource });
 
-    const originalDriveItem = await WebDavUtils.getAndSearchItemFromResource({
+    const originalDriveItem = await WebDavUtils.getDriveItemFromResource({
       resource,
       driveFolderService,
       driveFileService,
     });
+
+    if (!originalDriveItem) {
+      throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+    }
 
     if (destinationResource.path.dir === resource.path.dir) {
       // RENAME (the operation is from the same dir)
@@ -62,10 +66,15 @@ export class MOVERequestHandler implements WebDavMethodHandler {
       webdavLogger.info(`[MOVE] Moving ${resource.type} with UUID ${originalDriveItem.uuid} to ${destinationPath}`);
       const destinationFolderResource = await WebDavUtils.getRequestedResource(destinationResource.parentPath);
 
-      const destinationFolderItem = (await WebDavUtils.getAndSearchItemFromResource({
+      const destinationDriveFolderItem = await WebDavUtils.getDriveItemFromResource({
         resource: destinationFolderResource,
         driveFolderService,
-      })) as DriveFolderItem;
+      });
+
+      if (!destinationDriveFolderItem) {
+        throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+      }
+      const destinationFolderItem = destinationDriveFolderItem as DriveFileItem;
 
       if (resource.type === 'folder') {
         const folder = originalDriveItem as DriveFolderItem;

--- a/src/webdav/handlers/PUT.handler.ts
+++ b/src/webdav/handlers/PUT.handler.ts
@@ -6,7 +6,7 @@ import { WebDavMethodHandler } from '../../types/webdav.types';
 import { NotFoundError, UnsupportedMediaTypeError } from '../../utils/errors.utils';
 import { WebDavUtils } from '../../utils/webdav.utils';
 import { webdavLogger } from '../../utils/logger.utils';
-import { DriveFileItem, DriveFolderItem } from '../../types/drive.types';
+import { DriveFileItem } from '../../types/drive.types';
 import { DriveFolderService } from '../../services/drive/drive-folder.service';
 import { TrashService } from '../../services/drive/trash.service';
 import { EncryptionVersion } from '@internxt/sdk/dist/drive/storage/types';
@@ -43,15 +43,20 @@ export class PUTRequestHandler implements WebDavMethodHandler {
 
     const parentResource = await WebDavUtils.getRequestedResource(resource.parentPath, false);
 
-    const parentFolderItem = (await WebDavUtils.getAndSearchItemFromResource({
+    const parentDriveFolderItem = await WebDavUtils.getDriveItemFromResource({
       resource: parentResource,
       driveFolderService,
-    })) as DriveFolderItem;
+    });
+
+    if (!parentDriveFolderItem) {
+      throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+    }
+    const parentFolderItem = parentDriveFolderItem as DriveFileItem;
 
     try {
       // If the file already exists, the WebDAV specification states that 'PUT /…/file' should replace it.
       // http://www.webdav.org/specs/rfc4918.html#put-resources
-      const driveFileItem = (await WebDavUtils.getAndSearchItemFromResource({
+      const driveFileItem = (await WebDavUtils.getDriveItemFromResource({
         resource: resource,
         driveFileService,
       })) as DriveFileItem;

--- a/src/webdav/handlers/PUT.handler.ts
+++ b/src/webdav/handlers/PUT.handler.ts
@@ -3,7 +3,7 @@ import { DriveFileService } from '../../services/drive/drive-file.service';
 import { NetworkFacade } from '../../services/network/network-facade.service';
 import { AuthService } from '../../services/auth.service';
 import { WebDavMethodHandler } from '../../types/webdav.types';
-import { NotFoundError, UnsupportedMediaTypeError } from '../../utils/errors.utils';
+import { ConflictError, NotFoundError, UnsupportedMediaTypeError } from '../../utils/errors.utils';
 import { WebDavUtils } from '../../utils/webdav.utils';
 import { webdavLogger } from '../../utils/logger.utils';
 import { DriveFileItem } from '../../types/drive.types';
@@ -49,7 +49,11 @@ export class PUTRequestHandler implements WebDavMethodHandler {
     });
 
     if (!parentDriveFolderItem) {
-      throw new NotFoundError(`Resource not found on Internxt Drive at ${resource.url}`);
+      // WebDAV RFC
+      // When the PUT operation creates a new resource,
+      // all ancestors MUST already exist, or the method MUST fail
+      // with a 409 (Conflict) status code
+      throw new ConflictError(`Parent folders not found on Internxt Drive at ${resource.url}`);
     }
     const parentFolderItem = parentDriveFolderItem as DriveFileItem;
 

--- a/test/webdav/handlers/DELETE.handler.test.ts
+++ b/test/webdav/handlers/DELETE.handler.test.ts
@@ -37,14 +37,12 @@ describe('DELETE request handler', () => {
       status: vi.fn().mockReturnValue({ send: vi.fn() }),
     });
 
-    const expectedError = new NotFoundError(`Resource not found on Internxt Drive at ${requestedFileResource.url}`);
-
     const getRequestedResourceStub = vi
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFileResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
-      .mockRejectedValue(expectedError);
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
+      .mockResolvedValue(undefined);
 
     try {
       await requestHandler.handle(request, response);
@@ -78,7 +76,7 @@ describe('DELETE request handler', () => {
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFileResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValue(mockFile);
     const trashItemsStub = vi.spyOn(trashService, 'trashItems').mockResolvedValue();
 
@@ -112,7 +110,7 @@ describe('DELETE request handler', () => {
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFolderResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValue(mockFolder);
     const trashItemsStub = vi.spyOn(trashService, 'trashItems').mockResolvedValue();
 

--- a/test/webdav/handlers/GET.handler.test.ts
+++ b/test/webdav/handlers/GET.handler.test.ts
@@ -68,14 +68,12 @@ describe('GET request handler', () => {
       status: vi.fn().mockReturnValue({ send: vi.fn() }),
     });
 
-    const expectedError = new NotFoundError(`Resource not found on Internxt Drive at ${requestedFileResource.url}`);
-
     const getRequestedResourceStub = vi
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFileResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
-      .mockRejectedValue(expectedError);
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
+      .mockResolvedValue(undefined);
 
     try {
       await requestHandler.handle(request, response);
@@ -119,7 +117,7 @@ describe('GET request handler', () => {
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFileResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValue(mockFile);
     const authDetailsStub = vi.spyOn(authService, 'getAuthDetails').mockResolvedValue(mockAuthDetails);
     const downloadStreamStub = vi
@@ -188,7 +186,7 @@ describe('GET request handler', () => {
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFileResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValue(mockFile);
     const authDetailsStub = vi.spyOn(authService, 'getAuthDetails').mockResolvedValue(mockAuthDetails);
     const downloadStreamStub = vi

--- a/test/webdav/handlers/HEAD.handler.test.ts
+++ b/test/webdav/handlers/HEAD.handler.test.ts
@@ -60,7 +60,7 @@ describe('HEAD request handler', () => {
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFileResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValue(mockFile);
 
     await requestHandler.handle(request, response);
@@ -98,7 +98,7 @@ describe('HEAD request handler', () => {
       .spyOn(WebDavUtils, 'getRequestedResource')
       .mockResolvedValue(requestedFileResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValue(mockFile);
 
     await requestHandler.handle(request, response);

--- a/test/webdav/handlers/MKCOL.handler.test.ts
+++ b/test/webdav/handlers/MKCOL.handler.test.ts
@@ -11,7 +11,6 @@ import { CreateFolderResponse } from '@internxt/sdk/dist/drive/storage/types';
 import { newCreateFolderResponse, newFolderItem } from '../../fixtures/drive.fixture';
 import { WebDavRequestedResource } from '../../../src/types/webdav.types';
 import { WebDavUtils } from '../../../src/utils/webdav.utils';
-import { NotFoundError } from '../../../src/utils/errors.utils';
 
 describe('MKCOL request handler', () => {
   beforeEach(() => {
@@ -54,22 +53,19 @@ describe('MKCOL request handler', () => {
       .mockResolvedValueOnce(requestedParentFolderResource);
     const getAndSearchItemFromResourceStub = vi
       .spyOn(WebDavUtils, 'getDriveItemFromResource')
-      .mockResolvedValue(parentFolder);
+      .mockResolvedValueOnce(parentFolder)
+      .mockResolvedValueOnce(undefined);
     const createFolderStub = vi
       .spyOn(driveFolderService, 'createFolder')
       .mockReturnValue([Promise.resolve(newFolderResponse), { cancel: () => {} }]);
-    const getFolderBeforeItsCreation = vi
-      .spyOn(driveFolderService, 'getFolderMetadataByPath')
-      .mockRejectedValue(new NotFoundError('Folder not exists'));
 
     await requestHandler.handle(request, response);
     expect(response.status).toHaveBeenCalledWith(201);
     expect(getRequestedResourceStub).toHaveBeenCalledTimes(2);
-    expect(getAndSearchItemFromResourceStub).toHaveBeenCalledOnce();
+    expect(getAndSearchItemFromResourceStub).toHaveBeenCalledTimes(2);
     expect(createFolderStub).toHaveBeenCalledWith({
       plainName: requestedFolderResource.name,
       parentFolderUuid: parentFolder.uuid,
     });
-    expect(getFolderBeforeItsCreation).toHaveBeenCalledOnce();
   });
 });

--- a/test/webdav/handlers/MKCOL.handler.test.ts
+++ b/test/webdav/handlers/MKCOL.handler.test.ts
@@ -53,7 +53,7 @@ describe('MKCOL request handler', () => {
       .mockResolvedValueOnce(requestedFolderResource)
       .mockResolvedValueOnce(requestedParentFolderResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValue(parentFolder);
     const createFolderStub = vi
       .spyOn(driveFolderService, 'createFolder')

--- a/test/webdav/handlers/PUT.handler.test.ts
+++ b/test/webdav/handlers/PUT.handler.test.ts
@@ -118,9 +118,9 @@ describe('PUT request handler', () => {
       .mockResolvedValueOnce(requestedFileResource)
       .mockResolvedValueOnce(requestedParentFolderResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValueOnce(folderFixture)
-      .mockRejectedValue(new Error());
+      .mockResolvedValue(undefined);
     const getAuthDetailsStub = vi.spyOn(authService, 'getAuthDetails').mockResolvedValue(UserCredentialsFixture);
     const uploadStub = vi.spyOn(networkFacade, 'uploadFile').mockImplementation(
       // @ts-expect-error - We only mock the properties we need
@@ -180,7 +180,7 @@ describe('PUT request handler', () => {
       .mockResolvedValueOnce(requestedFileResource)
       .mockResolvedValueOnce(requestedParentFolderResource);
     const getAndSearchItemFromResourceStub = vi
-      .spyOn(WebDavUtils, 'getAndSearchItemFromResource')
+      .spyOn(WebDavUtils, 'getDriveItemFromResource')
       .mockResolvedValueOnce(folderFixture)
       .mockResolvedValueOnce(fileFixture.toItem());
     const deleteDriveFileStub = vi.spyOn(trashService, 'trashItems').mockResolvedValue();


### PR DESCRIPTION
- Replace getAndSearchItemFromResource with getDriveItemFromResource. It simplifies getDriveItemFromResource method and removes error handling
- Fixes PUT operation so it throws ConflictError if parent folders are not found
- Refactored folder verification at MKCOL operation