### PR TITLE
remove: update docker hub description from gh action

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -55,13 +55,3 @@ jobs:
           tags: |
             internxt/webdav:latest
             internxt/webdav:${{ env.DOCKER_TAG }}
-
-      - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v5
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: internxt/webdav
-          short-description: Official WebDAV server for Internxt
-          readme-filepath: ./docker/README.md
-          enable-url-completion: true


### PR DESCRIPTION
Removed the step `Update Docker Hub Description` from the `publish-docker-image.yml` as the user does not have enough permissions