### PR TITLE
Enhance the thrown conflict error with the info of the createFullPath and add more tests to verify said flag

### DIFF
--- a/src/webdav/services/webdav-folder.service.ts
+++ b/src/webdav/services/webdav-folder.service.ts
@@ -51,7 +51,8 @@ export class WebDavFolderService {
       // all ancestors MUST already exist, or the method MUST fail
       // with a 409 (Conflict) status code
       throw new ConflictError(
-        `Parent folders not found on Internxt Drive at ${WebDavUtils.decodeUrl(parentPath, false)}`,
+        `Parent folders not found on Internxt Drive at ${WebDavUtils.decodeUrl(parentPath, false)},
+        createFullPath flag is set to: ${createFullPath}`,
       );
     }
     const folders = parentPath.split('/').filter((f) => f.length > 0);

--- a/test/services/config.service.test.ts
+++ b/test/services/config.service.test.ts
@@ -178,4 +178,56 @@ describe('Config service', () => {
     expect(webdavConfigResult).to.be.deep.equal(defaultWebdavConfig);
     expect(fsStub).toHaveBeenCalledWith(ConfigService.WEBDAV_CONFIGS_FILE, 'utf8');
   });
+
+  it('should default to true when webdav config exists but createFullPath property is missing', async () => {
+    const partialWebdavConfig = {
+      host: '192.168.1.1',
+      port: '8080',
+      protocol: 'https',
+      timeoutMinutes: 30,
+    };
+    const stringConfig = JSON.stringify(partialWebdavConfig);
+
+    const fsStub = vi.spyOn(fs, 'readFile').mockResolvedValue(stringConfig);
+
+    const webdavConfigResult = await ConfigService.instance.readWebdavConfig();
+    expect(webdavConfigResult.createFullPath).to.be.equal(true);
+    expect(webdavConfigResult.host).to.be.equal(partialWebdavConfig.host);
+    expect(webdavConfigResult.port).to.be.equal(partialWebdavConfig.port);
+    expect(fsStub).toHaveBeenCalledWith(ConfigService.WEBDAV_CONFIGS_FILE, 'utf8');
+  });
+
+  it('shoud return false when webdav config has createFullPath explicitly set to false', async () => {
+    const webdavConfig = {
+      host: '192.168.1.1',
+      port: '8080',
+      protocol: 'https',
+      timeoutMinutes: 30,
+      createFullPath: false,
+    };
+    const stringConfig = JSON.stringify(webdavConfig);
+
+    const fsStub = vi.spyOn(fs, 'readFile').mockResolvedValue(stringConfig);
+
+    const webdavConfigResult = await ConfigService.instance.readWebdavConfig();
+    expect(webdavConfigResult.createFullPath).to.be.equal(false);
+    expect(fsStub).toHaveBeenCalledWith(ConfigService.WEBDAV_CONFIGS_FILE, 'utf8');
+  });
+
+  it('should return true when webdav config has createFullPath explicitly set to true', async () => {
+    const webdavConfig = {
+      host: '192.168.1.1',
+      port: '8080',
+      protocol: 'https',
+      timeoutMinutes: 30,
+      createFullPath: true,
+    };
+    const stringConfig = JSON.stringify(webdavConfig);
+
+    const fsStub = vi.spyOn(fs, 'readFile').mockResolvedValue(stringConfig);
+
+    const webdavConfigResult = await ConfigService.instance.readWebdavConfig();
+    expect(webdavConfigResult.createFullPath).to.be.equal(true);
+    expect(fsStub).toHaveBeenCalledWith(ConfigService.WEBDAV_CONFIGS_FILE, 'utf8');
+  });
 });


### PR DESCRIPTION
I have added more info in the thrown ConflictError when --no-createFullPath is activated to display what is the actual value of the flag.

Also added more tests to verify that only this value will be set to false if the user explicitly uses the --no-createFullPath flag