### PR TITLE
add tests to validateTokenAndCheckExpiration

### DIFF
--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -29,7 +29,7 @@ export default class Whoami extends Command {
       } else {
         if (validCreds.refreshRequired) {
           try {
-            await AuthService.instance.refreshUserToken(userCredentials);
+            await AuthService.instance.refreshAndStoreUserToken(userCredentials);
           } catch {
             /* noop */
           }

--- a/test/services/auth.service.test.ts
+++ b/test/services/auth.service.test.ts
@@ -231,7 +231,7 @@ describe('Auth service', () => {
       .spyOn(ValidationService.instance, 'validateTokenAndCheckExpiration')
       .mockImplementationOnce(() => mockToken);
     const validateMnemonicStub = vi.spyOn(ValidationService.instance, 'validateMnemonic').mockReturnValue(true);
-    const refreshTokensStub = vi.spyOn(sut, 'refreshUserToken').mockResolvedValue(UserCredentialsFixture);
+    const refreshTokensStub = vi.spyOn(sut, 'refreshAndStoreUserToken').mockResolvedValue(UserCredentialsFixture);
 
     await sut.getAuthDetails();
     expect(authStub).toHaveBeenCalledOnce();


### PR DESCRIPTION
- I renamed `refreshUserToken` to `refreshAndStoreUserToken` to better reflect the behaviour
- Deleted unused method `refreshUserDetails`
- Added tests to `validateTokenAndCheckExpiration` to properly verify the behavioyr