### PR TITLE
Docker Healthcheck uses a non-executable script (health_check.sh)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN yarn install
 RUN yarn build
 
 RUN chmod +x /app/docker/entrypoint.sh
+RUN chmod +x /app/docker/health_check.sh
 RUN ln -s '/app/bin/run.js' /usr/local/bin/internxt
 
 ENTRYPOINT ["/app/docker/entrypoint.sh"]


### PR DESCRIPTION
The Docker image defines the following healthcheck:

`HEALTHCHECK --interval=60s --timeout=20s --start-period=30s --retries=3 CMD /app/docker/health_check.sh`


However, inside the container the script is not executable:

```
/app/docker # ls -la
-rw-r--r--  root  root  634  health_check.sh   ← not executable
```


As a result, the healthcheck fails with:

`/bin/sh: /app/docker/health_check.sh: Permission denied`


The image should set the correct permissions, for example:

`RUN chmod +x /app/docker/health_check.sh`

https://github.com/internxt/cli/issues/416#issue-3627007924
