### PR TITLE
[PB-5111] Feat: upload folder command

### DIFF
--- a/src/commands/upload-folder.ts
+++ b/src/commands/upload-folder.ts
@@ -51,7 +51,7 @@ export default class UploadFolder extends Command {
       flags['json'],
     );
     progressBar?.start(100, 0);
-    const { data, error } = await UploadFacade.instance.uploadFolder({
+    const data = await UploadFacade.instance.uploadFolder({
       localPath: flags['folder'],
       destinationFolderUuid,
       loginUserDetails: user,
@@ -63,10 +63,6 @@ export default class UploadFolder extends Command {
 
     progressBar?.update(100);
     progressBar?.stop();
-
-    if (error) {
-      throw error;
-    }
 
     const driveUrl = ConfigService.instance.get('DRIVE_WEB_URL');
     const folderUrl = `${driveUrl}/folder/${data.rootFolderId}`;

--- a/src/services/network/upload/upload-facade.service.ts
+++ b/src/services/network/upload/upload-facade.service.ts
@@ -33,7 +33,7 @@ export class UploadFacade {
     });
 
     if (folderMap.size === 0) {
-      return { error: new Error('Failed to create folders, cannot upload files') };
+      throw new Error('Failed to create folders, cannot upload files');
     }
     // This aims to prevent this issue: https://inxt.atlassian.net/browse/PB-1446
     await AsyncUtils.sleep(500);
@@ -51,11 +51,9 @@ export class UploadFacade {
     const rootFolderName = basename(localPath);
     const rootFolderId = folderMap.get(rootFolderName) ?? '';
     return {
-      data: {
-        totalBytes,
-        rootFolderId,
-        uploadTimeMs: timer.stop(),
-      },
+      totalBytes,
+      rootFolderId,
+      uploadTimeMs: timer.stop(),
     };
   }
 }

--- a/test/commands/upload-folder.test.ts
+++ b/test/commands/upload-folder.test.ts
@@ -18,9 +18,7 @@ describe('Upload Folder Command', () => {
   let getAuthDetailsSpy: MockInstance<() => Promise<LoginCredentials>>;
   let validateDirectoryExistsSpy: MockInstance<(path: string) => Promise<boolean>>;
   let getDestinationFolderUuidSpy: MockInstance<() => Promise<string | undefined>>;
-  let UploadFacadeSpy: MockInstance<
-    () => Promise<{ data: UploadResult; error?: undefined } | { error: Error; data?: undefined }>
-  >;
+  let UploadFacadeSpy: MockInstance<() => Promise<UploadResult>>;
   let cliSuccessSpy: MockInstance<() => void>;
   const uploadedResult: UploadResult = {
     totalBytes: 1024,
@@ -37,9 +35,7 @@ describe('Upload Folder Command', () => {
       .spyOn(ValidationService.instance, 'validateDirectoryExists')
       .mockResolvedValue(true);
     getDestinationFolderUuidSpy = vi.spyOn(CLIUtils, 'getDestinationFolderUuid').mockResolvedValue(undefined);
-    UploadFacadeSpy = vi.spyOn(UploadFacade.instance, 'uploadFolder').mockResolvedValue({
-      data: uploadedResult,
-    });
+    UploadFacadeSpy = vi.spyOn(UploadFacade.instance, 'uploadFolder').mockResolvedValue(uploadedResult);
     cliSuccessSpy = vi.spyOn(CLIUtils, 'success').mockImplementation(() => {});
   });
 
@@ -87,25 +83,6 @@ describe('Upload Folder Command', () => {
         destinationFolderUuid: UserFixture.rootFolderId,
       }),
     );
-  });
-
-  it('should rethrow any error returned by UploadFacade.uploadFolder', async () => {
-    const uploadError = new Error('Unhandled upload error');
-    UploadFacadeSpy.mockResolvedValue({
-      error: uploadError,
-    });
-
-    const result = UploadFolder.run(['--folder=/valid/folder/path']);
-
-    await expect(result).rejects.toMatchObject({
-      message: expect.stringContaining('EEXIT: 1'),
-      oclif: { exit: 1 },
-    });
-
-    expect(getAuthDetailsSpy).toHaveBeenCalledOnce();
-    expect(validateDirectoryExistsSpy).toHaveBeenCalledWith('/valid/folder/path');
-    expect(getDestinationFolderUuidSpy).toHaveBeenCalledOnce();
-    expect(UploadFacadeSpy).toHaveBeenCalledOnce();
   });
 
   it('should call CLIUtils.success with proper message when upload succeeds', async () => {


### PR DESCRIPTION
## What has been Added
Added the upload command.
use:
```bash
internxt upload-folder --folder=/home/alexis/Documents/internxt/folder-example/
```
You can either upload it to root or to a certain folder id when this message appears on the terminal:
```bash
? What is the destination folder id? (leave empty for the root folder)
```
You can obtain said id with
```bash
internxt list
```