### PR TITLE
Preserve credentials after retryable token refresh failures

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -107,7 +107,9 @@ export class AuthService {
         );
         credentialsChanged = true;
       } catch (error) {
-        await ConfigService.instance.clearUser();
+        if (this.shouldClearUserAfterRefreshError(error)) {
+          await ConfigService.instance.clearUser();
+        }
         throw error;
       }
     }
@@ -124,6 +126,38 @@ export class AuthService {
       await ConfigService.instance.saveUser(loginCreds);
     }
     return loginCreds;
+  };
+
+  private readonly shouldClearUserAfterRefreshError = (error: unknown): boolean => {
+    if (error instanceof InvalidCredentialsError || error instanceof ExpiredCredentialsError) {
+      return true;
+    }
+
+    const status = this.getHttpStatusFromError(error);
+    if (status === undefined) {
+      return false;
+    }
+
+    return status >= 400 && status < 500 && status !== 408 && status !== 429;
+  };
+
+  private readonly getHttpStatusFromError = (error: unknown): number | undefined => {
+    if (typeof error !== 'object' || error === null) {
+      return undefined;
+    }
+
+    const response = 'response' in error ? (error as { response?: { status?: unknown } }).response : undefined;
+    if (typeof response?.status === 'number') {
+      return response.status;
+    }
+
+    const status = 'status' in error ? (error as { status?: unknown }).status : undefined;
+    if (typeof status === 'number') {
+      return status;
+    }
+
+    const statusCode = 'statusCode' in error ? (error as { statusCode?: unknown }).statusCode : undefined;
+    return typeof statusCode === 'number' ? statusCode : undefined;
   };
 
   /**

--- a/test/services/auth.service.test.ts
+++ b/test/services/auth.service.test.ts
@@ -217,12 +217,14 @@ describe('Auth service', () => {
     expect(refreshTokensStub).toHaveBeenCalledOnce();
   });
 
-  test('when the token refresh fails, then stored credentials are cleared and an error is thrown', async () => {
+  test('when the token refresh fails with an auth error, then stored credentials are cleared and an error is thrown', async () => {
     const sut = AuthService.instance;
 
     const mockTokenStatus = TokenStatus.REFRESH_REQUIRED;
 
-    const oldTokenError = new Error('Old token version detected');
+    const oldTokenError = Object.assign(new Error('Old token version detected'), {
+      response: { status: 401 },
+    });
 
     vi.spyOn(ConfigService.instance, 'readUser').mockResolvedValue(UserCredentialsFixture);
     vi.spyOn(ValidationService.instance, 'validateTokenAndCheckExpiration').mockImplementationOnce(
@@ -235,5 +237,27 @@ describe('Auth service', () => {
     await expect(() => sut.getAuthDetails()).rejects.toThrow(oldTokenError);
     expect(refreshTokenStub).toHaveBeenCalledOnce();
     expect(clearUserStub).toHaveBeenCalledOnce();
+  });
+
+  test('when the token refresh fails with a retryable server error, then stored credentials are preserved', async () => {
+    const sut = AuthService.instance;
+
+    const mockTokenStatus = TokenStatus.REFRESH_REQUIRED;
+
+    const retryableError = Object.assign(new Error('Service unavailable'), {
+      response: { status: 503 },
+    });
+
+    vi.spyOn(ConfigService.instance, 'readUser').mockResolvedValue(UserCredentialsFixture);
+    vi.spyOn(ValidationService.instance, 'validateTokenAndCheckExpiration').mockImplementationOnce(
+      () => mockTokenStatus,
+    );
+    vi.spyOn(ValidationService.instance, 'validateMnemonic').mockReturnValue(true);
+    const refreshTokenStub = vi.spyOn(sut, 'refreshUserToken').mockRejectedValue(retryableError);
+    const clearUserStub = vi.spyOn(ConfigService.instance, 'clearUser').mockResolvedValue();
+
+    await expect(() => sut.getAuthDetails()).rejects.toThrow(retryableError);
+    expect(refreshTokenStub).toHaveBeenCalledOnce();
+    expect(clearUserStub).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This changes token refresh failure handling so stored credentials are only cleared when the refresh failure indicates invalid or expired credentials.

Retryable failures such as `5xx`, `408`, `429`, or network/unknown errors now preserve the existing credentials and return the error to the caller. This avoids leaving long-running WebDAV sessions permanently logged out after a transient API failure.

## Why

A transient `503` during token refresh can currently clear the saved user credentials. After that, all following WebDAV requests fail with `Missing credentials, please login first` until the container is manually re-authenticated or restarted.

## Behavior

- Clear credentials for explicit auth/client failures such as `401`/`403`.
- Preserve credentials for retryable refresh failures such as `503`, `408`, `429`, or missing HTTP status.
- Re-throw the original error either way.

## Tests

- Added coverage for auth refresh `401` clearing credentials.
- Added coverage for auth refresh `503` preserving credentials.
- Verified targeted auth/WebDAV tests locally.
